### PR TITLE
Export template through gtm instead of editing the sandbox code directly

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -10,20 +10,24 @@ ___INFO___
 
 {
   "type": "TAG",
-  "id": "cvt_temp_public_id",
+  "id": "cvt_MQDKZ",
   "version": 1,
-  "securityGroups": [],
   "displayName": "Microsoft Clarity - Official",
-  "categories": ["ANALYTICS", "HEAT_MAP", "SESSION_RECORDING"],
+  "categories": [
+    "ANALYTICS",
+    "HEAT_MAP",
+    "SESSION_RECORDING"
+  ],
   "brand": {
-    "id": "Microsoft",
-    "displayName": "Microsoft",
+    "id": "github.com_microsoft",
+    "displayName": "microsoft",
     "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACABAMAAAAxEHz4AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAElBMVEUAAADyUCJ/ugAApO//uQD///8951e2AAAAAXRSTlMAQObYZgAAAAFiS0dEBfhv6ccAAAAHdElNRQfkCgUWITsZUDiiAAAAS0lEQVRo3u3MQQ3AIAAEsMuCAGZhCkiwgH9NOLj3Hq2A5q1m8nxVBAKBQCAQCAQCgUAgEPSAP9jVSsapBAKBQCAQCAQCgUAgEPTgAruK0CdlWNSzAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDIwLTEwLTA1VDIyOjMzOjU5KzAwOjAwPT1n8QAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyMC0xMC0wNVQyMjozMzo1OSswMDowMExg300AAAAASUVORK5CYII\u003d"
   },
   "description": "Clarity is a user behavior analytics tool, which helps you understand how users are interacting with your website. Supported features include:\nSession Recordings\nHeatmaps\nML Insights",
   "containerContexts": [
     "WEB"
-  ]
+  ],
+  "securityGroups": []
 }
 
 
@@ -355,6 +359,34 @@ ___WEB_PERMISSIONS___
     },
     "clientAnnotations": {
       "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "read_event_metadata",
+        "versionId": "1"
+      },
+      "param": []
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "read_data_layer",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "allowedKeys",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        }
+      ]
     },
     "isRequired": true
   }


### PR DESCRIPTION
- Instead of changing the code directly, I exported the template file through GTM.
- This is based on recommendation through GTM gallery template status page.
<img width="1466" height="796" alt="image" src="https://github.com/user-attachments/assets/dfa984af-00fe-42bf-a2d9-7e935212d5e3" />
