### PR TITLE
fix: add event to read_data_layer permission keyPatterns

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -385,6 +385,37 @@ ___WEB_PERMISSIONS___
             "type": 1,
             "string": "specific"
           }
+        },
+        {
+          "key": "keyPatterns",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "event"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
Fixes #15

copyFromDataLayer(\"event\") on line 222 requires read_data_layer permission for the event key. The current permissions declare allowedKeys: specific but provide no keyPatterns, causing GTM sandbox to throw: Prohibited read from data layer variable: event.

This adds event to the allowed keys list.